### PR TITLE
Fix TeX-fold-region

### DIFF
--- a/tex-fold-linebreaks.el
+++ b/tex-fold-linebreaks.el
@@ -133,7 +133,7 @@ strings in `tex-fold-linebreaks-sentence-end-punctuation'."
         (goto-char beg)
         (let* ((ms1 (match-string 1))
                (ms2 (match-string 2))
-               (r1 (assoc ms1 tex-fold-linebreaks-sentence-end-punctuation))
+               (r1 (cdr (assoc ms1 tex-fold-linebreaks-sentence-end-punctuation)))
                (rep (concat
                      r1
                      (if (string= ms1 ms2)


### PR DESCRIPTION
assoc returns the full matching value from the alist, not its cdr. Fixes #1. 
